### PR TITLE
Fix Proxy Address in package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,5 +28,5 @@
     "not ie <= 11",
     "not op_mini all"
   ],
-  "proxy": "http://bootcamp-pfrp-rest_backend_1:5000"
+  "proxy": "http://bootcamp-pfrp-rest-backend-1:5000"
 }


### PR DESCRIPTION
the proxy address in `package.json` was not correctly pointing to the docker container, which lead to the ECONNREFUSED error.